### PR TITLE
Different band input

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,10 +129,14 @@ Process *and* pansharpen a downloaded image:
 
 ``$: landsat process --pansharpen path/to/LC80090452014008LGN00.tar.bz``
 
+Use different bands to produce a false color image (default is 4, 3, 2)
+
+``$: landsat process path/to/LC80090452014008LGN00.tar.bz --bands 7 5 3``
+
+
 Search, download, and process images all at once using the --imageprocess flag:
 
 ``$: landsat search --imageprocess --cloud 6 --start "january 01 2014" --end "january 10 2014" shapefile path/to/shapefile.shp``
-
 
 Important Notes
 ===============

--- a/landsat/image_helper.py
+++ b/landsat/image_helper.py
@@ -90,7 +90,8 @@ class Process(object):
 
         self.verbosity.output('\nThe final image is stored here:',
                               normal=True)
-        self.verbosity.output(self.delivery_path + '/final.TIF\n',
+        band_string = ''.join(str(band) for band in self.bands)
+        self.verbosity.output(self.delivery_path + '/%s.TIF\n' % band_string,
                               normal=True, color='green')
 
         return
@@ -111,7 +112,8 @@ class Process(object):
 
         self.verbosity.output('\nThe final image is stored here:',
                               normal=True)
-        self.verbosity.output(self.delivery_path + '/final-pan.TIF\n',
+        band_string = ''.join(str(band) for band in self.bands)
+        self.verbosity.output(self.delivery_path + '/%s-pan.TIF\n' % band_string,
                               normal=True, color='green')
 
         return
@@ -188,10 +190,14 @@ class Process(object):
 
         self.verbosity.subprocess(argv)
 
+        band_string = ''.join(str(band) for band in self.bands)
+        argv = ['mv', '%s/final-pan.TIF' % self.final_path, '%s/%s-pan.TIF' % (self.final_path,band_string) ]
+        self.verbosity.subprocess(argv)
+
         self.verbosity.output('Done',
                               normal=True, indent=1)
 
-        return '%s/final-pan.TIF' % self.final_path
+        return '%s/%s-pan.TIF' % (self.final_path, band_string)
 
     def _create_mask(self):
 
@@ -257,10 +263,15 @@ class Process(object):
 
         self.verbosity.subprocess(argv)
 
+        band_string = ''.join(str(band) for band in self.bands)
+        argv = ['mv', '%s/final.TIF' % self.final_path, '%s/%s.TIF' % (self.final_path,band_string) ]
+        self.verbosity.subprocess(argv)
+
+
         self.verbosity.output('Done',
                               normal=True, indent=1)
 
-        return '%s/final.TIF' % self.final_path
+        return '%s/%s.TIF' % (self.final_path, band_string)
 
     def _final_conversions(self):
         """ Final color conversions. Return final image temp path """

--- a/landsat/landsat.py
+++ b/landsat/landsat.py
@@ -58,6 +58,9 @@ search, download, and process Landsat imagery.
 
             -d, --download        Use this flag to download found images
 
+            -b BAND1 BAND2 BAND3, --bands BAND1 BAND2 BAND3 
+                                The default bands are 4, 3, 2         
+
             --imageprocess      If this flag is used, the images are downloaded
                                 and process. Be cautious as it might take a
                                 long time to both download and process large
@@ -152,6 +155,7 @@ def args_options():
                                            help='Process Landsat imagery')
     parser_process.add_argument('path',
                                 help='Path to the compressed image file')
+    parser_process.add_argument('-b', '--bands', nargs=3, help='Specify which bands to use')
     parser_process.add_argument('--pansharpen', action='store_true',
                                 help='Whether to also pansharpen the process '
                                 'image. Pan sharpening takes a long time')
@@ -167,6 +171,8 @@ def main(args):
     if args:
         if args.subs == 'process':
             p = Process(args.path)
+            if args.bands:
+              p.bands = args.bands
             if args.pansharpen:
                 p.full_with_pansharpening()
             else:


### PR DESCRIPTION
This PR adds a flag `-b | --bands` that accepts 3 numbers to produce a false color image. 

Example:

``$: landsat process path/to/LC80090452014008LGN00.tar.bz --bands 7 5 3``