### PR TITLE
Relaxed GDAL version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-GDAL==1.11.0
+GDAL
 elasticsearch==1.1.1
 gsutil==4.4
 requests==2.3.0
-python-dateutil==2.2
+python-dateutil==2.4
 nose==1.3.3
 pdoc==0.2.4
 numpy

--- a/setup.py
+++ b/setup.py
@@ -51,11 +51,11 @@ setup(name="landsat",
       license="CCO",
       platforms="Posix; MacOS X; Windows",
       install_requires=[
-          "GDAL==1.11.0",
+          "GDAL",
           "elasticsearch==1.1.1",
           "gsutil==4.4",
           "requests==2.3.0",
-          "python-dateutil==2.2",
+          "python-dateutil==2.4",
           "numpy"
       ],
       )


### PR DESCRIPTION
Updated python-dateutil to 2.4 to avoid issues with permissions not being set correctly on version 2.2.