### PR TITLE
Fix process command documentation

### DIFF
--- a/landsat/landsat.py
+++ b/landsat/landsat.py
@@ -132,7 +132,7 @@ def args_options():
                                            help='Process Landsat imagery')
     parser_process.add_argument('path',
                                 help='Path to the compressed image file')
-    parser_process.add_argument('--pansharpen', action='store_true',
+    parser_process.add_argument('-p', '--pansharpen', action='store_true',
                                 help='Whether to also pansharpen the process '
                                 'image. Pan sharpening takes a long time')
     parser_process.add_argument('-b', '--bands', help='specify band combinations. Default is 432'

--- a/landsat/tests/test_landsat.py
+++ b/landsat/tests/test_landsat.py
@@ -42,6 +42,9 @@ class TestLandsat(unittest.TestCase):
         except SystemExit as e:
             self.assertEqual(e.code, code)
 
+    def parse_args(self, args):
+        return self.parser.parse_args(args)
+
     def test_incorrect_date(self):
         """ Test search with incorrect date input """
 
@@ -110,6 +113,10 @@ class TestLandsat(unittest.TestCase):
         """ Check if the commandline performs correctly """
 
         self.assertEqual(subprocess.call(['python', join(self.base_dir, '../landsat.py'), '-h']), 0)
+
+    def test_pansharpen_p(self):
+        """ Check that process -p enables pansharpening """
+        self.assertEqual(self.parse_args(['process', '-p', 'does not exist']).pansharpen, True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The -p argument is not accepted by the `process` subcommand, so remove it from command documentation.

I'd also be happy to modify the `process` subcommand to accept -p if you'd prefer.