### PR TITLE
Allow rasterio > 0.18

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
       'python-dateutil==2.2',
       'numpy==1.9.1',
       'termcolor==1.1.0',
-      'rasterio==0.18',
+      'rasterio>=0.18',
       'six==1.9.0',
       'scipy==0.15.1',
       'scikit-image==0.10.1',


### PR DESCRIPTION
Hey all, I installed landsat-util and it downgraded my venv's Rasterio and Requests because landsat-util requires 0.18 and 2.5.3 exactly. Rasterio 0.19 and 0.20 should be compatible with landsat-util and have important new features and fixes. https://packaging.python.org/en/latest/requirements.html#install-requires cautions about pinning to specific versions and I agree with the PyPA authors.

I suggest you consider changing `==` to `>=` in some other requirements too.