### PR TITLE
Add an option for parallel downloading

### DIFF
--- a/landsat/landsat.py
+++ b/landsat/landsat.py
@@ -91,7 +91,7 @@ search, download, and process Landsat imagery.
 
                 --force-unzip       Force unzip tar file
 
-		--use-aria2c        Use aria2c for parallel downloading
+		--use-aria2        Use aria2 for parallel downloading
 
         Process:
             landsat.py process path [-h] [-b --bands] [-p --pansharpen]
@@ -193,7 +193,7 @@ def args_options():
     parser_download.add_argument('--bucket', help='Bucket name (required if uploading to s3)')
     parser_download.add_argument('--region', help='URL to S3 region e.g. s3-us-west-2.amazonaws.com')
     parser_download.add_argument('--force-unzip', help='Force unzip tar file', action='store_true')
-    parser_download.add_argument('--use-aria2c', help='Use aria2c for parallel downloading')
+    parser_download.add_argument('--use-aria2', help='Use aria2 for parallel downloading', action='store_true')
 
     parser_process = subparsers.add_parser('process', help='Process Landsat imagery')
     parser_process.add_argument('path',
@@ -289,7 +289,9 @@ def main(args):
             elif result['status'] == 'error':
                 return [result['message'], 1]
         elif args.subs == 'download':
-            d = Downloader(download_dir=args.dest)
+            print (args)
+            use_aria2 = True if args.use_aria2 else False
+            d = Downloader(download_dir=args.dest, use_aria2=use_aria2)
             try:
                 bands = convert_to_integer_list(args.bands)
                 if args.pansharpen:
@@ -297,7 +299,7 @@ def main(args):
                 if args.ndvi:
                     bands = [4, 5]
 
-                downloaded = d.download(args.scenes, bands, args.use_aria2c)
+                downloaded = d.download(args.scenes, bands)
 
                 if args.process:
                     force_unzip = True if args.force_unzip else False

--- a/landsat/landsat.py
+++ b/landsat/landsat.py
@@ -289,7 +289,6 @@ def main(args):
             elif result['status'] == 'error':
                 return [result['message'], 1]
         elif args.subs == 'download':
-            print (args)
             use_aria2 = True if args.use_aria2 else False
             d = Downloader(download_dir=args.dest, use_aria2=use_aria2)
             try:

--- a/landsat/landsat.py
+++ b/landsat/landsat.py
@@ -91,6 +91,8 @@ search, download, and process Landsat imagery.
 
                 --force-unzip       Force unzip tar file
 
+		--use-aria2c        Use aria2c for parallel downloading
+
         Process:
             landsat.py process path [-h] [-b --bands] [-p --pansharpen]
 
@@ -191,6 +193,7 @@ def args_options():
     parser_download.add_argument('--bucket', help='Bucket name (required if uploading to s3)')
     parser_download.add_argument('--region', help='URL to S3 region e.g. s3-us-west-2.amazonaws.com')
     parser_download.add_argument('--force-unzip', help='Force unzip tar file', action='store_true')
+    parser_download.add_argument('--use-aria2c', help='Use aria2c for parallel downloading')
 
     parser_process = subparsers.add_parser('process', help='Process Landsat imagery')
     parser_process.add_argument('path',
@@ -294,7 +297,7 @@ def main(args):
                 if args.ndvi:
                     bands = [4, 5]
 
-                downloaded = d.download(args.scenes, bands)
+                downloaded = d.download(args.scenes, bands, args.use_aria2c)
 
                 if args.process:
                     force_unzip = True if args.force_unzip else False

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,3 +8,4 @@ scikit-image>=0.11.3
 homura>=0.1.1
 scipy>=0.15.1
 boto>=2.38.0
+aria2>=1.18.1

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -8,6 +8,7 @@ import errno
 import shutil
 import unittest
 from tempfile import mkdtemp
+import logging
 
 import mock
 
@@ -97,6 +98,8 @@ class TestDownloader(unittest.TestCase):
         mock_fetch.return_value = True
 
         scene = self.scene_s3
+        log= logging.getLogger( "tests.test_download.TestDownloader" )
+        log.debug( "mock_fetch= %r", mock_fetch )
         self.assertTrue(self.d.amazon_s3(scene, 11, self.temp_folder))
 
         # If scene id is incorrect
@@ -111,6 +114,8 @@ class TestDownloader(unittest.TestCase):
 
         sat = self.d.scene_interpreter(self.scene)
         url = self.d.google_storage_url(sat)
+        log= logging.getLogger( "tests.test_download.TestDownloader" )
+        log.debug( "mock_fetch= %r", mock_fetch )
 
         self.assertTrue(self.d.fetch(url, self.temp_folder, self.scene))
 

--- a/tests/test_landsat.py
+++ b/tests/test_landsat.py
@@ -74,7 +74,7 @@ class TestLandsat(unittest.TestCase):
 
         args = ['download', 'LC80010092015051LGN00', '-b', '11,', '-d', self.mock_path]
         output = landsat.main(self.parser.parse_args(args))
-        #mock_downloader.assert_called_with(download_dir=self.mock_path)
+
         mock_downloader.assert_called_with(download_dir=self.mock_path, use_aria2=False)
         mock_downloader.return_value.download.assert_called_with(['LC80010092015051LGN00'], [11])
         self.assertEquals(output, ['Download Completed', 0])

--- a/tests/test_landsat.py
+++ b/tests/test_landsat.py
@@ -74,9 +74,17 @@ class TestLandsat(unittest.TestCase):
 
         args = ['download', 'LC80010092015051LGN00', '-b', '11,', '-d', self.mock_path]
         output = landsat.main(self.parser.parse_args(args))
-        mock_downloader.assert_called_with(download_dir=self.mock_path)
+        #mock_downloader.assert_called_with(download_dir=self.mock_path)
+        mock_downloader.assert_called_with(download_dir=self.mock_path, use_aria2=False)
         mock_downloader.return_value.download.assert_called_with(['LC80010092015051LGN00'], [11])
         self.assertEquals(output, ['Download Completed', 0])
+
+        args = ['download', 'LC80010092015051LGN00', '-b', '11,', '-d', self.mock_path, '--use-aria2']
+        output = landsat.main(self.parser.parse_args(args))
+        mock_downloader.assert_called_with(download_dir=self.mock_path, use_aria2=True)
+        mock_downloader.return_value.download.assert_called_with(['LC80010092015051LGN00'], [11])
+        self.assertEquals(output, ['Download Completed', 0])
+
 
     def test_download_incorrect(self):
         """Test download command with incorrect input"""


### PR DESCRIPTION
As I've proposed in Issue #102, these are the modifications in order to allow the use of new command-line flag --use-aria2c true, in order to download the scenes using aria2c's parallel download.
This is my first contribution so, in case something looks odd, just let me know, ok?
Cheers.