### PR TITLE
update join method for download URL

### DIFF
--- a/landsat/downloader.py
+++ b/landsat/downloader.py
@@ -186,7 +186,7 @@ class Downloader(VerbosityMixin):
             (String) The URL to a google storage file
         """
         filename = sat['scene'] + '.tar.bz'
-        return join(self.google, sat['sat'], sat['path'], sat['row'], filename)
+        return "/".join([self.google, sat['sat'], sat['path'], sat['row'], filename])
 
     def amazon_s3_url(self, sat, filename):
         """
@@ -204,7 +204,7 @@ class Downloader(VerbosityMixin):
         :returns:
             (String) The URL to a S3 file
         """
-        return join(self.s3, sat['sat'], sat['path'], sat['row'], sat['scene'], filename)
+        return "/".join([self.s3, sat['sat'], sat['path'], sat['row'], sat['scene'], filename])
 
     def remote_file_exists(self, url):
         """ Checks whether the remote file exists.

--- a/landsat/settings.py
+++ b/landsat/settings.py
@@ -14,8 +14,8 @@ DEBUG = getenv('DEBUG', False)
 
 SATELLITE = 'L8'
 L8_METADATA_URL = 'http://landsat.usgs.gov/metadata_service/bulk_metadata_files/LANDSAT_8.csv'
-GOOGLE_STORAGE = 'http://storage.googleapis.com/earthengine-public/landsat/'
-S3_LANDSAT = 'http://landsat-pds.s3.amazonaws.com/'
+GOOGLE_STORAGE = 'http://storage.googleapis.com/earthengine-public/landsat'
+S3_LANDSAT = 'http://landsat-pds.s3.amazonaws.com'
 API_URL = 'https://api.developmentseed.org/landsat'
 
 # User's Home Directory


### PR DESCRIPTION
replaced join() with "/".join() for building google and Amazon S3 URLs
that are compatible across platforms. Remove trailing "/" from S3 and
Google base URL in  settings.py