### PR TITLE
Correct default for download

### DIFF
--- a/landsat/landsat.py
+++ b/landsat/landsat.py
@@ -197,7 +197,7 @@ def args_options():
                                  help="Provide Full sceneID, e.g. LC81660392014196LGN00")
 
     parser_download.add_argument('-b', '--bands', help='If you specify bands, landsat-util will try to download '
-                                 'the band from S3. If the band does not exist, an error is returned', default='432')
+                                 'the band from S3. If the band does not exist, an error is returned', default='')
     parser_download.add_argument('-d', '--dest', help='Destination path')
     parser_download.add_argument('-p', '--process', help='Process the image after download', action='store_true')
     parser_download.add_argument('--pansharpen', action='store_true',


### PR DESCRIPTION
`landsat download LC80450332015023LGN00` should download the tar.gz file with all bands by default, but the default is being set to '432'. This does not do anything for scenes prior to 2015 on Google Storage, but for 2015 on AWS it only downloads those bands. This is not expected behaviour according to the docs, and it makes it hard to download the whole tar archive (you need to use `landsat download LC80450332015023LGN00 -b ""`)