### PR TITLE
Update docs and help to show '--clip=' syntax

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -68,7 +68,7 @@ Commands
 
                     --clip              Clip the image with the bounding box provided. Values must be in WGS84 datum,
                                         and with longitude and latitude units of decimal degrees separated by comma.
-                                        Example: --clip -346.06658935546875,49.93531194616915,-345.4595947265625,50.2682767372753
+                                        Example: --clip=-346.06658935546875,49.93531194616915,-345.4595947265625,50.2682767372753
 
                     -u --upload         Upload to S3 after the image processing completed
 
@@ -104,7 +104,7 @@ Commands
 
                     --clip              Clip the image with the bounding box provided. Values must be in WGS84 datum,
                                         and with longitude and latitude units of decimal degrees separated by comma.
-                                        Example: --clip -346.06658935546875,49.93531194616915,-345.4595947265625,50.2682767372753
+                                        Example: --clip=-346.06658935546875,49.93531194616915,-345.4595947265625,50.2682767372753
 
                     -v, --verbose       Show verbose output
 

--- a/landsat/landsat.py
+++ b/landsat/landsat.py
@@ -91,7 +91,7 @@ search, download, and process Landsat imagery.
 
                 --clip              Clip the image with the bounding box provided. Values must be in WGS84 datum,
                                     and with longitude and latitude units of decimal degrees separated by comma.
-                                    Example: --clip -346.06658935546875,49.93531194616915,-345.4595947265625,
+                                    Example: --clip=-346.06658935546875,49.93531194616915,-345.4595947265625,
                                     50.2682767372753
 
                 -u --upload         Upload to S3 after the image processing completed
@@ -128,7 +128,7 @@ search, download, and process Landsat imagery.
 
                 --clip              Clip the image with the bounding box provided. Values must be in WGS84 datum,
                                     and with longitude and latitude units of decimal degrees separated by comma.
-                                    Example: --clip -346.06658935546875,49.93531194616915,-345.4595947265625,
+                                    Example: --clip=-346.06658935546875,49.93531194616915,-345.4595947265625,
                                     50.2682767372753
 
                 -v, --verbose       Show verbose output
@@ -214,7 +214,7 @@ def args_options():
     parser_download.add_argument('--clip', help='Clip the image with the bounding box provided. Values must be in ' +
                                  'WGS84 datum, and with longitude and latitude units of decimal degrees ' +
                                  'separated by comma.' +
-                                 'Example: --clip -346.06658935546875,49.93531194616915,-345.4595947265625,' +
+                                 'Example: --clip=-346.06658935546875,49.93531194616915,-345.4595947265625,' +
                                  '50.2682767372753')
     parser_download.add_argument('-u', '--upload', action='store_true',
                                  help='Upload to S3 after the image processing completed')
@@ -237,7 +237,7 @@ def args_options():
     parser_process.add_argument('--clip', help='Clip the image with the bounding box provided. Values must be in ' +
                                 'WGS84 datum, and with longitude and latitude units of decimal degrees ' +
                                 'separated by comma.' +
-                                'Example: --clip -346.06658935546875,49.93531194616915,-345.4595947265625,' +
+                                'Example: --clip=-346.06658935546875,49.93531194616915,-345.4595947265625,' +
                                 '50.2682767372753')
     parser_process.add_argument('-b', '--bands', help='specify band combinations. Default is 432'
                                 'Example: --bands 321', default='432')


### PR DESCRIPTION
Using the --clip parameter with a negative value at the beginning results in an error while parsing the arguments (#147).
Updating the docs at least does not leave the user alone in this situation. This is considered a workaround.