### PR TITLE
fixes issue #145

### DIFF
--- a/landsat/landsat.py
+++ b/landsat/landsat.py
@@ -324,8 +324,15 @@ def main(args):
             s = Search()
 
             try:
-                lat = float(args.lat) if args.lat else None
-                lon = float(args.lon) if args.lon else None
+                if args.lat is not None:
+                    lat = float(args.lat)
+                else:
+                    lat = None
+
+                if args.lon is not None:
+                    lon = float(args.lon)
+                else:
+                    lon = None
             except ValueError:
                 return ["The latitude and longitude values must be valid numbers", 1]
 

--- a/landsat/search.py
+++ b/landsat/search.py
@@ -218,7 +218,7 @@ class Search(object):
 
         if address:
             query.append(self.address_builder(address))
-        elif lat and lon:
+        elif (lat is not None) and (lon is not None):
             query.append(self.lat_lon_builder(lat, lon))
 
         if query:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -34,6 +34,18 @@ class TestSearchHelper(unittest.TestCase):
         result = self.s.search(lat=lat, lon=lon, start_date=start_date, end_date=end_date)
         self.assertEqual('2015-02-06', result['results'][0]['date'])
 
+    def test_search_zero_lon(self):
+        # Make sure that zero coordinates are handled correctly
+        paths_rows = '003,003'
+        lon = 0.0
+        lat = 52.0
+        start_date = '2016-01-01'
+        end_date = '2016-01-10'
+
+        result = self.s.search(start_date=start_date, end_date=end_date,
+                               lon=0.0, lat=52.0)
+        self.assertEqual('2016-01-06', result['results'][0]['date'])
+
     def test_search_with_geojson(self):
 
         # TEST A REGULAR SEARCH WITH KNOWN RESULT for paths and rows


### PR DESCRIPTION
This pull request should fix #145.

In two places, landsat-util tests for the presense of lon/lat with

```python
    if lon:
        [...]
    if lat:
        [...]
```

but this fails when `lon == 0` or `lat == 0`

Replaced with explicit checks for `None`. Added testcase.