### PR TITLE
Python 3 is now supported

### DIFF
--- a/landsat/decorators.py
+++ b/landsat/decorators.py
@@ -1,4 +1,5 @@
 import warnings
+
 import rasterio
 
 

--- a/landsat/downloader.py
+++ b/landsat/downloader.py
@@ -1,5 +1,8 @@
 # Landsat Util
 # License: CC0 1.0 Universal
+
+from __future__ import print_function, division, absolute_import
+
 from xml.etree import ElementTree
 from os.path import join, exists, getsize
 
@@ -7,9 +10,9 @@ import requests
 from usgs import api, USGSError
 from homura import download as fetch
 
-from utils import check_create_folder, url_builder
-from mixins import VerbosityMixin
-import settings
+from .utils import check_create_folder, url_builder
+from .mixins import VerbosityMixin
+from . import settings
 
 
 class RemoteFileDoesntExist(Exception):

--- a/landsat/image.py
+++ b/landsat/image.py
@@ -2,6 +2,8 @@
 # Landsat Util
 # License: CC0 1.0 Universal
 
+from __future__ import print_function, division, absolute_import
+
 import os
 import tarfile
 import glob
@@ -20,9 +22,9 @@ from skimage.util import img_as_ubyte
 from skimage.exposure import rescale_intensity
 from polyline.codec import PolylineCodec
 
-from mixins import VerbosityMixin
-from utils import get_file, check_create_folder, exit, adjust_bounding_box
-from decorators import rasterio_decorator
+from .mixins import VerbosityMixin
+from .utils import get_file, check_create_folder, exit, adjust_bounding_box
+from .decorators import rasterio_decorator
 
 
 class FileDoesNotExist(Exception):

--- a/landsat/landsat.py
+++ b/landsat/landsat.py
@@ -3,11 +3,17 @@
 # Landsat Util
 # License: CC0 1.0 Universal
 
+from __future__ import print_function, division, absolute_import
+
 import argparse
 import textwrap
 import json
 from os.path import join
-from urllib2 import URLError
+
+try:
+    from urllib.request import URLError
+except ImportError:
+    from urllib2 import URLError
 
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
@@ -15,15 +21,15 @@ from dateutil.parser import parse
 import pycurl
 from boto.exception import NoAuthHandlerFound
 
-from downloader import Downloader, IncorrectSceneId, RemoteFileDoesntExist, USGSInventoryAccessMissing
-from search import Search
-from uploader import Uploader
-from utils import reformat_date, convert_to_integer_list, timer, exit, get_file, convert_to_float_list
-from mixins import VerbosityMixin
-from image import Simple, PanSharpen, FileDoesNotExist
-from ndvi import NDVIWithManualColorMap, NDVI
-from __init__ import __version__
-import settings
+from .downloader import Downloader, IncorrectSceneId, RemoteFileDoesntExist, USGSInventoryAccessMissing
+from .search import Search
+from .uploader import Uploader
+from .utils import reformat_date, convert_to_integer_list, timer, exit, get_file, convert_to_float_list
+from .mixins import VerbosityMixin
+from .image import Simple, PanSharpen, FileDoesNotExist
+from .ndvi import NDVIWithManualColorMap, NDVI
+from .__init__ import __version__
+from . import settings
 
 
 DESCRIPTION = """Landsat-util is a command line utility that makes it easy to
@@ -465,10 +471,10 @@ def process_image(path, bands=None, verbose=False, pansharpen=False, ndvi=False,
             p = Simple(path, bands=bands, dst_path=settings.PROCESSED_IMAGE, verbose=verbose, force_unzip=force_unzip,
                        bounds=bounds)
 
-    except IOError as e:
-        exit(e.message, 1)
-    except FileDoesNotExist as e:
-        exit(e.message, 1)
+    except IOError as err:
+        exit(str(err), 1)
+    except FileDoesNotExist as err:
+        exit(str(err), 1)
 
     return p.run()
 

--- a/landsat/mixins.py
+++ b/landsat/mixins.py
@@ -2,6 +2,8 @@
 # Landsat Util
 # License: CC0 1.0 Universal
 
+from __future__ import print_function, division, absolute_import
+
 import sys
 import subprocess
 from termcolor import colored
@@ -108,6 +110,6 @@ class VerbosityMixin(object):
         if indent:
             msg = ('     ' * indent) + msg
 
-        sys.stdout.write(msg + '\n')
+        print(msg)
 
         return msg

--- a/landsat/ndvi.py
+++ b/landsat/ndvi.py
@@ -1,11 +1,13 @@
+from __future__ import print_function, division, absolute_import
+
 from os.path import join
 
 import rasterio
 import numpy
 
-import settings
-from decorators import rasterio_decorator
-from image import BaseProcess
+from . import settings
+from .decorators import rasterio_decorator
+from .image import BaseProcess
 
 
 class NDVI(BaseProcess):
@@ -45,7 +47,7 @@ class NDVI(BaseProcess):
         except IOError:
             pass
 
-        self.cmap = {k: v[:4] for k, v in colormap.iteritems()}
+        self.cmap = {k: v[:4] for k, v in colormap.items()}
 
     @rasterio_decorator
     def run(self):

--- a/landsat/search.py
+++ b/landsat/search.py
@@ -1,12 +1,14 @@
 # Landsat Util
 # License: CC0 1.0 Universal
 
+from __future__ import print_function, division, absolute_import
+
 import json
 import time
 import requests
 
-import settings
-from utils import three_digit, create_paired_list, geocode
+from . import settings
+from .utils import three_digit, create_paired_list, geocode
 
 
 class Search(object):

--- a/landsat/utils.py
+++ b/landsat/utils.py
@@ -1,15 +1,23 @@
 # Landsat Util
 # License: CC0 1.0 Universal
 
+from __future__ import print_function, division, absolute_import
+
 import os
 import sys
 import time
 import re
-from cStringIO import StringIO
+
+try:
+    from io import StringIO
+except ImportError:
+    from cStringIO import StringIO
+
 from datetime import datetime
+
 import geocoder
 
-from mixins import VerbosityMixin
+from .mixins import VerbosityMixin
 
 
 class Capturing(list):
@@ -43,7 +51,7 @@ class timer(object):
 
     def __exit__(self, type, value, traceback):
         self.end = time.time()
-        print 'Time spent : {0:.2f} seconds'.format((self.end - self.start))
+        print('Time spent : {0:.2f} seconds'.format((self.end - self.start)))
 
 
 def exit(message, code=0):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -8,6 +8,7 @@ import errno
 import shutil
 import unittest
 from tempfile import mkdtemp
+
 import rasterio
 from rasterio.warp import transform_bounds
 
@@ -62,7 +63,8 @@ class TestProcess(unittest.TestCase):
                    bounds=bounds)
         path = p.run()
         self.assertTrue(exists(path))
-        self.assertEqual(map('{0:.2f}'.format, get_bounds(path)), map('{0:.2f}'.format, bounds))
+        for val, exp in zip(get_bounds(path), bounds):
+            self.assertAlmostEqual(val, exp, 2)
 
     def test_simple_with_intersecting_bounds_clip(self):
 
@@ -72,7 +74,8 @@ class TestProcess(unittest.TestCase):
                    bounds=bounds)
         path = p.run()
         self.assertTrue(exists(path))
-        self.assertEqual(map('{0:.2f}'.format, get_bounds(path)), map('{0:.2f}'.format, expected_bounds))
+        for val, exp in zip(get_bounds(path), expected_bounds):
+            self.assertAlmostEqual(val, exp, 2)
 
     def test_simple_with_out_of_bounds_clip(self):
 
@@ -82,7 +85,8 @@ class TestProcess(unittest.TestCase):
                    bounds=bounds)
         path = p.run()
         self.assertTrue(exists(path))
-        self.assertEqual(map('{0:.2f}'.format, get_bounds(path)), map('{0:.2f}'.format, expected_bounds))
+        for val, exp in zip(get_bounds(path), expected_bounds):
+            self.assertAlmostEqual(val, exp, 2)
 
     def test_simple_with_zip_file(self):
 
@@ -104,7 +108,8 @@ class TestProcess(unittest.TestCase):
                        bounds=bounds)
         path = p.run()
         self.assertTrue(exists(path))
-        self.assertEqual(map('{0:.2f}'.format, get_bounds(path)), map('{0:.2f}'.format, bounds))
+        for val, exp in zip(get_bounds(path), bounds):
+            self.assertAlmostEqual(val, exp, 2)
 
     def test_ndvi(self):
 
@@ -118,7 +123,8 @@ class TestProcess(unittest.TestCase):
                  bounds=bounds)
         path = p.run()
         self.assertTrue(exists(path))
-        self.assertEqual(map('{0:.2f}'.format, get_bounds(path)), map('{0:.2f}'.format, bounds))
+        for val, exp in zip(get_bounds(path), bounds):
+            self.assertAlmostEqual(val, exp, 2)
 
     def test_ndvi_with_manual_colormap(self):
 

--- a/tests/test_landsat.py
+++ b/tests/test_landsat.py
@@ -8,10 +8,10 @@ import unittest
 import subprocess
 import errno
 import shutil
-import mock
 from os.path import join
-from jsonschema import validate
 
+from jsonschema import validate
+import mock
 
 import landsat.landsat as landsat
 from tests import geojson_schema

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -3,9 +3,16 @@
 
 """Tests for mixins"""
 
+from __future__ import absolute_import
+
 import sys
 import unittest
-from cStringIO import StringIO
+
+try:
+    from io import StringIO
+except:
+    from cStringIO import StringIO
+
 from contextlib import contextmanager
 
 from landsat.mixins import VerbosityMixin
@@ -30,45 +37,45 @@ class TestMixins(unittest.TestCase):
 
     def test_output(self):
         # just a value
-        with capture(self.v.output, 'this is a test') as output:
+        with capture(self.v.output, u'this is a test') as output:
             self.assertEquals("", output)
 
         # value as normal
-        with capture(self.v.output, 'this is a test', normal=True) as output:
+        with capture(self.v.output, u'this is a test', normal=True) as output:
             self.assertEquals("this is a test\n", output)
 
         # value as normal with color
-        with capture(self.v.output, 'this is a test', normal=True, color='blue') as output:
+        with capture(self.v.output, u'this is a test', normal=True, color='blue') as output:
             self.assertEquals("\x1b[34mthis is a test\x1b[0m\n", output)
 
         # value as error
-        with capture(self.v.output, 'this is a test', normal=True, error=True) as output:
+        with capture(self.v.output, u'this is a test', normal=True, error=True) as output:
             self.assertEquals("\x1b[31mthis is a test\x1b[0m\n", output)
 
         # value with arrow
-        with capture(self.v.output, 'this is a test', normal=True, arrow=True) as output:
+        with capture(self.v.output, u'this is a test', normal=True, arrow=True) as output:
             self.assertEquals("\x1b[34m===> \x1b[0mthis is a test\n", output)
 
         # value with indent
-        with capture(self.v.output, 'this is a test', normal=True, indent=1) as output:
+        with capture(self.v.output, u'this is a test', normal=True, indent=1) as output:
             self.assertEquals("     this is a test\n", output)
 
     def test_exit(self):
         with self.assertRaises(SystemExit):
-            with capture(self.v.exit, 'exit test') as output:
+            with capture(self.v.exit, u'exit test') as output:
                 self.assertEquals('exit test', output)
 
     def test_print(self):
         # message in blue with arrow
-        with capture(self.v._print, msg='this is a test', color='blue', arrow=True) as output:
+        with capture(self.v._print, msg=u'this is a test', color='blue', arrow=True) as output:
             self.assertEquals("\x1b[34m===> \x1b[0m\x1b[34mthis is a test\x1b[0m\n", output)
 
         # just a message
-        with capture(self.v._print, msg='this is a test') as output:
+        with capture(self.v._print, msg=u'this is a test') as output:
             self.assertEquals("this is a test\n", output)
 
         # message with color and indent
-        with capture(self.v._print, msg='this is a test', color='blue', indent=1) as output:
+        with capture(self.v._print, msg=u'this is a test', color='blue', indent=1) as output:
             self.assertEquals("     \x1b[34mthis is a test\x1b[0m\n", output)
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -4,6 +4,7 @@
 """Tests for search"""
 
 import unittest
+
 from jsonschema import validate
 
 from landsat.search import Search

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -34,11 +34,11 @@ class TestUploader(unittest.TestCase):
 class upload_tests(unittest.TestCase):
 
     def test_should_be_able_to_upload_data(self):
-        input = ['12', '345']
+        input = [b'12', b'345']
         state['mock_boto_s3_multipart_upload_data'] = []
         conn = S3Connection('some_key', 'some_secret', True)
         upload('test_bucket', 'some_key', 'some_secret', input, 'some_key', connection=conn)
-        self.assertEqual(state['mock_boto_s3_multipart_upload_data'], ['12', '345'])
+        self.assertEqual(state['mock_boto_s3_multipart_upload_data'], [b'12', b'345'])
 
 
 class upload_part_tests(unittest.TestCase):
@@ -57,36 +57,36 @@ class upload_part_tests(unittest.TestCase):
             counter[0] += 1
             raise Exception()
 
-        upload_part(upload_func, '_', '_', '_')
+        upload_part(upload_func, b'_', b'_', b'_')
         self.assertEqual(counter[0], 5)
 
 
 class doc_collector_tests(unittest.TestCase):
 
     def test_should_be_able_to_read_every_byte_of_data(self):
-        input = ['12345']
+        input = [b'12345']
         result = list(data_collector(input, def_buf_size=3))
-        self.assertEqual(result, ['123', '45'])
+        self.assertEqual(result, [b'123', b'45'])
 
     def test_should_be_able_to_read_single_yield(self):
-        input = ['123']
+        input = [b'123']
         result = list(data_collector(input, def_buf_size=3))
-        self.assertEqual(result, ['123'])
+        self.assertEqual(result, [b'123'])
 
     def test_should_be_able_to_yield_data_less_than_buffer_size(self):
-        input = ['123']
+        input = [b'123']
         result = list(data_collector(input, def_buf_size=6))
-        self.assertEqual(result, ['123'])
+        self.assertEqual(result, [b'123'])
 
     def test_a_single_item_should_still_be_buffered_even_if_it_is_above_the_buffer_size(self):
-        input = ['123456']
+        input = [b'123456']
         result = list(data_collector(input, def_buf_size=3))
-        self.assertEqual(result, ['123', '456'])
+        self.assertEqual(result, [b'123', b'456'])
 
     def test_should_return_rest_of_data_on_last_iteration(self):
-        input = ['1234', '56']
+        input = [b'1234', b'56']
         result = list(data_collector(input, def_buf_size=3))
-        self.assertEqual(result, ['123', '456'])
+        self.assertEqual(result, [b'123', b'456'])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist = 
+    py27
+    py35
+
+[testenv]
+deps =
+    jsonschema
+    mock>=1.3.0
+    nose>=1.3.7
+    pytest
+commands =
+    py.test


### PR DESCRIPTION
After I adjusted imports to be absolute and handled renaming of some modules, the rest of the work was sorting out the distinction between `bytes` and `str`. The uploader was written for ordinary strings of bytes and needed to be changed to actual bytes for Python 3.

There's one test failing on Python 2.7, complaining about `image.TIF`, but it passes on Python 3.5.

I believe there's some project work yet to be done to get Travis to run tests for py35.

Closes #170