### PR TITLE
Change default bands args to None to match docs

### DIFF
--- a/landsat/landsat.py
+++ b/landsat/landsat.py
@@ -216,7 +216,7 @@ def args_options():
                                  help="Provide Full sceneID, e.g. LC81660392014196LGN00")
 
     parser_download.add_argument('-b', '--bands', help='If you specify bands, landsat-util will try to download '
-                                 'the band from S3. If the band does not exist, an error is returned', default='')
+                                 'the band from S3. If the band does not exist, an error is returned', default=None)
     parser_download.add_argument('-d', '--dest', help='Destination path')
     parser_download.add_argument('-p', '--process', help='Process the image after download', action='store_true')
     parser_download.add_argument('--pansharpen', action='store_true',


### PR DESCRIPTION
As reported in #191, Google Storage is not used to download Landsat 8 .tar.bz files even if they are available, as the list of bands is set to '' by default. Changing this to None fixes this.

I imagine the previous behaviour is not intentional, as it means that if no --bands argument is passed then the only files that are downloaded are the _MTL.txt and _BQA.tif files.
