### PR TITLE
Current color correction base on cloud coverage will darken images

### DIFF
--- a/landsat/image.py
+++ b/landsat/image.py
@@ -275,7 +275,7 @@ class BaseProcess(VerbosityMixin):
             return band
         else:
             self.output("Color correcting band %s" % band_id, normal=True, color='green', indent=1)
-            p_low, cloud_cut_low = self._percent_cut(band, low, 100 - (coverage * 3 / 4))
+            p_low, cloud_cut_low = self._percent_cut(band, low, 100 - coverage)
             temp = numpy.zeros(numpy.shape(band), dtype=numpy.uint16)
             cloud_divide = 65000 - coverage * 100
             mask = numpy.logical_and(band < cloud_cut_low, band > 0)


### PR DESCRIPTION
Before change this line, our image looks below, it's too dark.
![old](https://cloud.githubusercontent.com/assets/240131/19991518/f106e39c-a270-11e6-8d6b-9e51804270cc.jpg)

After change this line, seems color correction will have brighten result at area of land.
![new](https://cloud.githubusercontent.com/assets/240131/19991527/1478096e-a271-11e6-8006-46dff9baa8be.jpg)

I suppose current cloud coverage based color correction could have some improvment. But I still not understand why minus 1/4 cloud will have such different result.

Just leave this pull request for reference these issues:
#66 , #128