### PR TITLE
Use Landsat Collection 1 dataset for USGS

### DIFF
--- a/landsat/downloader.py
+++ b/landsat/downloader.py
@@ -96,12 +96,14 @@ class Downloader(VerbosityMixin):
                 error_text = error_tree.find("SOAP-ENV:Body/SOAP-ENV:Fault/faultstring", api.NAMESPACES).text
                 raise USGSInventoryAccessMissing(error_text)
 
-            download_url = api.download('LANDSAT_8', 'EE', [scene], api_key=api_key)
-            if download_url:
-                self.output('Source: USGS EarthExplorer', normal=True, arrow=True)
-                return self.fetch(download_url[0], path)
+            response = api.download('LANDSAT_8_C1', 'EE', [scene], api_key=api_key)
+            try:
+                download_url = response['data'][0]
+            except IndexError:
+                raise RemoteFileDoesntExist('%s is not available on AWS S3, Google or USGS Earth Explorer' % scene)
+            self.output('Source: USGS EarthExplorer', normal=True, arrow=True)
+            return self.fetch(download_url, path)
 
-            raise RemoteFileDoesntExist('%s is not available on AWS S3, Google or USGS Earth Explorer' % scene)
         raise RemoteFileDoesntExist('%s is not available on AWS S3 or Google Storage' % scene)
 
     def google_storage(self, scene, path):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-usgs==0.1.9
+usgs>=0.2.0
 requests==2.7.0
 python-dateutil==2.5.1
 numpy==1.10.4


### PR DESCRIPTION
This makes the USGS download pull Landsat 8 Collection 1 data, solving (in part) https://github.com/developmentseed/landsat-util/issues/229

The solution is very simple: Change the dataset name to `LANDSAT_8_C1` as suggested in https://github.com/kapadia/usgs/issues/34 and slightly change the way the `download_url` is retrieved from the USGS API response.

Also, `usgs` should be updated to `v0.2.0`.

Fixes https://github.com/developmentseed/landsat-util/issues/233.

However, this does **not** address https://github.com/developmentseed/landsat-util/issues/234 (SOAP).